### PR TITLE
Add rate limiting and config validation with persistent lead storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Runtime environment
+NODE_ENV=development
+PORT=3000
+
+# Static asset directory override (optional)
+# STATIC_DIR=./public
+
+# Comma-separated list of allowed origins for CORS (optional)
+# CORS_ORIGIN=https://app.example.com,https://partners.example.com
+
+# Lead capture rate limiting
+RATE_LIMIT_ENABLED=true
+RATE_LIMIT_WINDOW_MS=60000
+RATE_LIMIT_MAX=10
+
+# Persistence
+DATABASE_URL=./data/leads.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Run tests
+        run: npm test
+
+      - name: Audit dependencies
+        run: npm audit --production

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .env
 coverage/
+data/

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "nodemon server/index.js",
     "start": "node server/index.js",
-    "test": "cross-env NODE_ENV=test jest --runInBand"
+    "test": "cross-env NODE_ENV=test jest --runInBand",
+    "lint": "node scripts/lint.js"
   },
   "engines": {
     "node": ">=18.0.0"
@@ -18,7 +19,6 @@
     "express": "^4.19.2",
     "helmet": "^7.0.0",
     "morgan": "^1.10.0",
-    "nanoid": "^5.0.7",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const targets = ['server', 'public'];
+let hasErrors = false;
+
+const collectFiles = (root) => {
+    const absoluteRoot = path.resolve(process.cwd(), root);
+    if (!fs.existsSync(absoluteRoot)) {
+        return [];
+    }
+
+    const stack = [absoluteRoot];
+    const files = [];
+
+    while (stack.length > 0) {
+        const current = stack.pop();
+        const stat = fs.statSync(current);
+
+        if (stat.isDirectory()) {
+            const entries = fs.readdirSync(current);
+            for (const entry of entries) {
+                if (entry === 'node_modules' || entry.startsWith('.')) {
+                    continue;
+                }
+                stack.push(path.join(current, entry));
+            }
+        } else if (current.endsWith('.js')) {
+            files.push(current);
+        }
+    }
+
+    return files;
+};
+
+const filesToCheck = targets.flatMap(collectFiles);
+
+for (const file of filesToCheck) {
+    const source = fs.readFileSync(file, 'utf8');
+    try {
+        new vm.Script(source, { filename: file });
+    } catch (error) {
+        hasErrors = true;
+        console.error(`Syntax error in ${path.relative(process.cwd(), file)}:\n${error.message}`);
+    }
+}
+
+if (hasErrors) {
+    process.exit(1);
+}
+
+console.log(`Checked ${filesToCheck.length} JavaScript files.`);

--- a/server/app.js
+++ b/server/app.js
@@ -7,72 +7,101 @@ const contactRouter = require('./routes/contact');
 const newsletterRouter = require('./routes/newsletter');
 const healthRouter = require('./routes/health');
 const { HttpError } = require('./utils/httpError');
+const baseConfig = require('./config');
+const { createRateLimiter } = require('./middleware/rateLimiter');
 
-const app = express();
-
-app.disable('x-powered-by');
-
-app.use(helmet({
-    contentSecurityPolicy: false
-}));
-
-const corsOrigins = process.env.CORS_ORIGIN
-    ? process.env.CORS_ORIGIN.split(',').map(origin => origin.trim()).filter(Boolean)
-    : null;
-
-if (corsOrigins && corsOrigins.length > 0) {
-    app.use(cors({ origin: corsOrigins }));
-}
-
-app.use(express.json());
-app.use(express.urlencoded({ extended: false }));
-
-if (process.env.NODE_ENV !== 'test') {
-    app.use(morgan('combined'));
-}
-
-app.use('/api/health', healthRouter);
-app.use('/api/contact', contactRouter);
-app.use('/api/newsletter', newsletterRouter);
-app.use('/api', (req, res, next) => {
-    next(new HttpError(404, 'Not found'));
+const mergeConfig = (overrides = {}) => ({
+    ...baseConfig,
+    ...overrides,
+    cors: {
+        origins: overrides.cors?.origins ?? baseConfig.cors.origins
+    },
+    rateLimit: {
+        enabled: overrides.rateLimit?.enabled ?? baseConfig.rateLimit.enabled,
+        windowMs: overrides.rateLimit?.windowMs ?? baseConfig.rateLimit.windowMs,
+        max: overrides.rateLimit?.max ?? baseConfig.rateLimit.max
+    }
 });
 
-const staticDir = process.env.STATIC_DIR
-    ? path.resolve(process.env.STATIC_DIR)
-    : path.resolve(__dirname, '..', 'public');
+const createApp = (overrides = {}) => {
+    const config = mergeConfig(overrides);
+    const app = express();
 
-app.use(express.static(staticDir));
+    app.disable('x-powered-by');
 
-app.get('*', (req, res) => {
-    if (req.path.startsWith('/api/')) {
-        res.status(404).json({ status: 'error', message: 'Not found' });
-        return;
-    }
-    res.sendFile(path.join(staticDir, 'index.html'));
-});
+    app.use(helmet({
+        contentSecurityPolicy: false
+    }));
 
-// eslint-disable-next-line no-unused-vars
-app.use((err, req, res, next) => {
-    const status = err.status || 500;
-    const response = {
-        status: 'error',
-        message: status >= 500 ? 'Something went wrong on our end.' : err.message
-    };
-
-    if (err.details) {
-        response.errors = err.details;
+    if (config.cors.origins.length > 0) {
+        app.use(cors({ origin: config.cors.origins }));
     }
 
-    if (status >= 500) {
-        console.error(err);
+    app.use(express.json());
+    app.use(express.urlencoded({ extended: false }));
+
+    if (config.env !== 'test') {
+        app.use(morgan('combined'));
     }
 
-    if (res.headersSent) {
-        return;
+    if (config.rateLimit.enabled) {
+        const leadCaptureLimiter = createRateLimiter({
+            windowMs: config.rateLimit.windowMs,
+            max: config.rateLimit.max
+        });
+
+        app.use('/api/contact', leadCaptureLimiter);
+        app.use('/api/newsletter', leadCaptureLimiter);
     }
 
-    res.status(status).json(response);
-});
+    app.use('/api/health', healthRouter);
+    app.use('/api/contact', contactRouter);
+    app.use('/api/newsletter', newsletterRouter);
+    app.use('/api', (req, res, next) => {
+        next(new HttpError(404, 'Not found'));
+    });
+
+    const staticDir = config.staticDir
+        ? path.resolve(config.staticDir)
+        : path.resolve(__dirname, '..', 'public');
+
+    app.use(express.static(staticDir));
+
+    app.get('*', (req, res) => {
+        if (req.path.startsWith('/api/')) {
+            res.status(404).json({ status: 'error', message: 'Not found' });
+            return;
+        }
+        res.sendFile(path.join(staticDir, 'index.html'));
+    });
+
+    // eslint-disable-next-line no-unused-vars
+    app.use((err, req, res, next) => {
+        const status = err.status || 500;
+        const response = {
+            status: 'error',
+            message: status >= 500 ? 'Something went wrong on our end.' : err.message
+        };
+
+        if (err.details) {
+            response.errors = err.details;
+        }
+
+        if (status >= 500) {
+            console.error(err);
+        }
+
+        if (res.headersSent) {
+            return;
+        }
+
+        res.status(status).json(response);
+    });
+
+    return app;
+};
+
+const app = createApp();
 
 module.exports = app;
+module.exports.createApp = createApp;

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -1,0 +1,78 @@
+const path = require('path');
+const { z } = require('zod');
+
+const coerceBoolean = (value, defaultValue = false) => {
+    if (value === undefined || value === null || value === '') {
+        return defaultValue;
+    }
+
+    if (typeof value === 'boolean') {
+        return value;
+    }
+
+    const normalized = value.trim().toLowerCase();
+
+    if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) {
+        return true;
+    }
+
+    if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) {
+        return false;
+    }
+
+    throw new Error(`Invalid boolean value "${value}" for environment flag.`);
+};
+
+const parseOrigins = (value) => {
+    if (!value) {
+        return [];
+    }
+
+    return value
+        .split(',')
+        .map(origin => origin.trim())
+        .filter(Boolean);
+};
+
+const defaultDatabasePath = path.join(process.cwd(), 'data', 'leads.json');
+
+const configSchema = z.object({
+    env: z.enum(['development', 'test', 'production']).default('development'),
+    port: z.coerce.number().int().positive().default(3000),
+    staticDir: z.string().trim().min(1).optional(),
+    corsOrigins: z.array(z.string().trim().min(1)).default([]),
+    rateLimitEnabled: z.boolean(),
+    rateLimitWindowMs: z.coerce.number().int().positive().default(60_000),
+    rateLimitMax: z.coerce.number().int().positive().default(10),
+    databaseUrl: z.string().trim().min(1).default(defaultDatabasePath)
+});
+
+const parsed = configSchema.parse({
+    env: process.env.NODE_ENV,
+    port: process.env.PORT,
+    staticDir: process.env.STATIC_DIR,
+    corsOrigins: parseOrigins(process.env.CORS_ORIGIN),
+    rateLimitEnabled: coerceBoolean(process.env.RATE_LIMIT_ENABLED, true),
+    rateLimitWindowMs: process.env.RATE_LIMIT_WINDOW_MS,
+    rateLimitMax: process.env.RATE_LIMIT_MAX,
+    databaseUrl: process.env.DATABASE_URL
+});
+
+const config = {
+    env: parsed.env,
+    port: parsed.port,
+    staticDir: parsed.staticDir,
+    cors: {
+        origins: parsed.corsOrigins
+    },
+    rateLimit: {
+        enabled: parsed.rateLimitEnabled,
+        windowMs: parsed.rateLimitWindowMs,
+        max: parsed.rateLimitMax
+    },
+    database: {
+        url: parsed.databaseUrl
+    }
+};
+
+module.exports = Object.freeze(config);

--- a/server/index.js
+++ b/server/index.js
@@ -1,8 +1,9 @@
 require('dotenv').config();
 const app = require('./app');
+const config = require('./config');
 
-const port = process.env.PORT || 3000;
+const port = config.port;
 
 app.listen(port, () => {
-    console.log(`Aurora Analytics server listening on port ${port}`);
+    console.log(`Aurora Analytics server listening on port ${port} (${config.env})`);
 });

--- a/server/middleware/rateLimiter.js
+++ b/server/middleware/rateLimiter.js
@@ -1,0 +1,57 @@
+const DEFAULT_KEY_GENERATOR = (req) => req.ip || req.headers['x-forwarded-for'] || req.connection?.remoteAddress || 'global';
+
+const clampToSeconds = (timestamp) => Math.ceil(timestamp / 1000);
+
+const createRateLimiter = ({ windowMs, max, keyGenerator = DEFAULT_KEY_GENERATOR }) => {
+    if (!Number.isInteger(windowMs) || windowMs <= 0) {
+        throw new Error('windowMs must be a positive integer.');
+    }
+
+    if (!Number.isInteger(max) || max <= 0) {
+        throw new Error('max must be a positive integer.');
+    }
+
+    const hits = new Map();
+
+    return (req, res, next) => {
+        const now = Date.now();
+        const key = keyGenerator(req);
+        const windowStart = now - windowMs;
+
+        const recentHits = (hits.get(key) || []).filter(timestamp => timestamp > windowStart);
+
+        if (recentHits.length === 0) {
+            hits.delete(key);
+        }
+
+        if (recentHits.length >= max) {
+            const retryAfterMs = recentHits[0] + windowMs - now;
+            const retryAfterSeconds = Math.max(1, clampToSeconds(retryAfterMs));
+            const resetAt = clampToSeconds(recentHits[0] + windowMs);
+
+            res.setHeader('X-RateLimit-Limit', String(max));
+            res.setHeader('X-RateLimit-Remaining', '0');
+            res.setHeader('X-RateLimit-Reset', String(resetAt));
+            res.setHeader('Retry-After', String(retryAfterSeconds));
+
+            res.status(429).json({
+                status: 'error',
+                message: 'Too many requests. Please wait before retrying.'
+            });
+            return;
+        }
+
+        recentHits.push(now);
+        hits.set(key, recentHits);
+
+        const resetAt = clampToSeconds(recentHits[0] + windowMs);
+        const remaining = Math.max(0, max - recentHits.length);
+
+        res.setHeader('X-RateLimit-Limit', String(max));
+        res.setHeader('X-RateLimit-Remaining', String(remaining));
+        res.setHeader('X-RateLimit-Reset', String(resetAt));
+        next();
+    };
+};
+
+module.exports = { createRateLimiter };

--- a/server/repositories/leadRepository.js
+++ b/server/repositories/leadRepository.js
@@ -1,0 +1,40 @@
+const { getDefaultStore } = require('../storage/leadStore');
+
+class LeadRepository {
+    constructor(store = getDefaultStore()) {
+        this.store = store;
+    }
+
+    createContact(record) {
+        const data = this.store.read();
+        data.contacts.push(record);
+        this.store.write(data);
+        return { ...record };
+    }
+
+    createNewsletterSubscription(record) {
+        const data = this.store.read();
+        data.newsletterSubscribers.push(record);
+        this.store.write(data);
+        return { ...record };
+    }
+
+    listContacts() {
+        const data = this.store.read();
+        return [...data.contacts];
+    }
+
+    listNewsletterSubscribers() {
+        const data = this.store.read();
+        return [...data.newsletterSubscribers];
+    }
+
+    reset() {
+        this.store.reset();
+    }
+}
+
+module.exports = {
+    LeadRepository,
+    defaultLeadRepository: new LeadRepository()
+};

--- a/server/services/leadService.js
+++ b/server/services/leadService.js
@@ -1,42 +1,48 @@
-const { nanoid } = require('nanoid');
+const { randomUUID } = require('crypto');
+const { defaultLeadRepository } = require('../repositories/leadRepository');
+
+const createIdentifier = (length) => {
+    const id = randomUUID().replace(/-/g, '');
+    return length ? id.slice(0, length) : id;
+};
 
 class LeadService {
-    constructor() {
-        this.reset();
+    constructor(repository = defaultLeadRepository) {
+        this.repository = repository;
     }
 
     createContact(payload) {
         const record = {
-            id: nanoid(12),
+            id: createIdentifier(12),
             receivedAt: new Date().toISOString(),
             ...payload
         };
-        this.contacts.push(record);
-        return record;
+
+        return this.repository.createContact(record);
     }
 
     createNewsletterSubscription(payload) {
         const record = {
-            id: nanoid(10),
+            id: createIdentifier(10),
             receivedAt: new Date().toISOString(),
             ...payload
         };
-        this.newsletterSubscribers.push(record);
-        return record;
+
+        return this.repository.createNewsletterSubscription(record);
     }
 
     listContacts() {
-        return [...this.contacts];
+        return this.repository.listContacts();
     }
 
     listNewsletterSubscribers() {
-        return [...this.newsletterSubscribers];
+        return this.repository.listNewsletterSubscribers();
     }
 
     reset() {
-        this.contacts = [];
-        this.newsletterSubscribers = [];
+        this.repository.reset();
     }
 }
 
 module.exports = new LeadService();
+module.exports.createLeadService = (repository) => new LeadService(repository);

--- a/server/storage/leadStore.js
+++ b/server/storage/leadStore.js
@@ -1,0 +1,83 @@
+const fs = require('fs');
+const path = require('path');
+const config = require('../config');
+
+const defaultState = () => ({
+    contacts: [],
+    newsletterSubscribers: []
+});
+
+const normalizePath = (targetPath) => targetPath.startsWith('file:')
+    ? targetPath.slice(5)
+    : targetPath;
+
+const ensureDirectory = (targetPath) => {
+    const directory = path.dirname(targetPath);
+    if (!fs.existsSync(directory)) {
+        fs.mkdirSync(directory, { recursive: true });
+    }
+};
+
+class LeadStore {
+    constructor(filePath = config.database.url) {
+        const normalized = normalizePath(filePath);
+        this.memoryOnly = normalized === ':memory:' || normalized === 'memory:';
+
+        if (!this.memoryOnly) {
+            this.filePath = path.isAbsolute(normalized)
+                ? normalized
+                : path.resolve(process.cwd(), normalized);
+
+            ensureDirectory(this.filePath);
+
+            if (!fs.existsSync(this.filePath)) {
+                fs.writeFileSync(this.filePath, JSON.stringify(defaultState(), null, 2));
+            }
+        } else {
+            this.state = defaultState();
+        }
+    }
+
+    read() {
+        if (this.memoryOnly) {
+            return { ...this.state, contacts: [...this.state.contacts], newsletterSubscribers: [...this.state.newsletterSubscribers] };
+        }
+
+        const raw = fs.readFileSync(this.filePath, 'utf8');
+        return JSON.parse(raw);
+    }
+
+    write(data) {
+        if (this.memoryOnly) {
+            this.state = {
+                contacts: [...data.contacts],
+                newsletterSubscribers: [...data.newsletterSubscribers]
+            };
+            return;
+        }
+
+        const payload = JSON.stringify(data, null, 2);
+        const tempPath = `${this.filePath}.tmp`;
+        fs.writeFileSync(tempPath, payload);
+        fs.renameSync(tempPath, this.filePath);
+    }
+
+    reset() {
+        this.write(defaultState());
+    }
+}
+
+let defaultStore;
+
+const getDefaultStore = () => {
+    if (!defaultStore) {
+        defaultStore = new LeadStore();
+    }
+    return defaultStore;
+};
+
+module.exports = {
+    LeadStore,
+    getDefaultStore,
+    defaultState
+};

--- a/server/tests/api.test.js
+++ b/server/tests/api.test.js
@@ -1,6 +1,10 @@
+process.env.DATABASE_URL = ':memory:';
+
 const request = require('supertest');
-const app = require('../app');
+const { createApp } = require('../app');
 const leadService = require('../services/leadService');
+
+const app = createApp();
 
 describe('Aurora Analytics API', () => {
     describe('POST /api/contact', () => {

--- a/server/tests/rateLimit.test.js
+++ b/server/tests/rateLimit.test.js
@@ -1,0 +1,46 @@
+process.env.DATABASE_URL = ':memory:';
+
+const request = require('supertest');
+
+const ORIGINAL_ENV = { ...process.env };
+
+const buildTestApp = () => {
+    const { createApp } = require('../app');
+    return createApp({
+        env: 'test',
+        rateLimit: {
+            enabled: true,
+            windowMs: 2000,
+            max: 2
+        }
+    });
+};
+
+describe('Rate limiting', () => {
+    afterEach(() => {
+        process.env = { ...ORIGINAL_ENV };
+    });
+
+    it('throttles repeated submissions from the same client', async () => {
+        const app = buildTestApp();
+        const payload = {
+            name: 'Jordan Fisher',
+            email: 'jordan@lumenwave.com',
+            company: 'LumenWave',
+            message: 'We need help forecasting a multi-region rollout.'
+        };
+
+        const first = await request(app).post('/api/contact').send(payload);
+        const second = await request(app).post('/api/contact').send(payload);
+        const blocked = await request(app).post('/api/contact').send(payload);
+
+        expect(first.status).toBe(201);
+        expect(second.status).toBe(201);
+        expect(blocked.status).toBe(429);
+        expect(blocked.headers['retry-after']).toBeDefined();
+        expect(blocked.body).toMatchObject({
+            status: 'error',
+            message: expect.stringContaining('Too many requests')
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- replace nanoid identifiers with crypto-based UUIDs and remove the dependency
- add a configuration loader with schema validation and expose an app factory for overrides
- introduce a reusable rate limiter with documentation and tests for throttling behavior
- persist leads using a file-backed repository with a configurable storage path and in-memory test mode
- add a syntax lint script and CI workflow that runs lint, tests, and dependency audits

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da77b3c520832da81c4f576f388632